### PR TITLE
Support for HTML which contains "equals" characters

### DIFF
--- a/lib/html-doc.js
+++ b/lib/html-doc.js
@@ -24,9 +24,9 @@ module.exports = {
             return source;
         }
 
-        var pieces = stripCommentDelimiters(source).split(/\+?=/);
-        var name = pieces.shift().trim();
-        var markup = pieces.join();
+        var pieces = stripCommentDelimiters(source).split(/</);
+        var name = pieces.shift().split(/\+?=/).shift().trim();
+        var markup = '<'+pieces.join('<');
 
         if (name) {
             source = convertToMultiLineComment(source);

--- a/test/html-doc-test.js
+++ b/test/html-doc-test.js
@@ -90,5 +90,22 @@ buster.testCase("HTML doc", {
         assert.exception(function () {
             vm.runInNewContext(htmlDoc.extract(comment), this.context);
         });
+    },
+
+    "allows elements with attributes": function()
+    {
+        var comment = "/*:DOC += <div id=\"test\"></div> */";
+        vm.runInNewContext(htmlDoc.extract(comment), this.context);
+
+        assert.equals(this.context.document.body.firstChild.getAttribute('id'), 'test');
+    },
+
+    "allows plus and equals in the HTML": function()
+    {
+        var comment = "/*:DOC += <div data-test=\"test+=test\">+=+</div> */";
+        vm.runInNewContext(htmlDoc.extract(comment), this.context);
+
+        assert.equals(this.context.document.body.firstChild.getAttribute('data-test'), 'test+=test');
+        assert.equals(this.context.document.body.firstChild.textContent, '+=+');
     }
 });


### PR DESCRIPTION
Not sure what's the roadmap on this, so made a trivial simple thing - instead of splitting by "=" to recombine with an empty delimiter, but instead extract the part before the first "<" as name.

I wonder... is it OK to look at JsTestDriver source to port the full featureset?..
